### PR TITLE
A more reliable way to check for browser support for postMessage.

### DIFF
--- a/src/porthole.js
+++ b/src/porthole.js
@@ -335,12 +335,12 @@ iFrame proxy abc.com->abc.com: forwardMessageEvent(event)
         }
     });
 
-    if (typeof window.postMessage !== 'function') {
-        Porthole.trace('Using legacy browser support');
-        Porthole.WindowProxy = Porthole.WindowProxyLegacy.extend({});
-    } else {
+    if (!!window.postMessage) {
         Porthole.trace('Using built-in browser support');
         Porthole.WindowProxy = Porthole.WindowProxyHTML5.extend({});
+    } else {
+        Porthole.trace('Using legacy browser support');
+        Porthole.WindowProxy = Porthole.WindowProxyLegacy.extend({});
     }
 
     /**


### PR DESCRIPTION
Taken from http://modernizr.com/

In my testing

  typeof window.postMessage

returns 'object' in IE8

!!window.postMessage gives a simple true/false