### PR TITLE
ADD ability for receiver only legacyWindows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Create your content iFrame. This is where the guest content lives. Make sure to 
 Define an event handler if you want to receive messages.
 
 ```javascript
-function onMessage(messageEvent) {  
+function onMessage(messageEvent) {
     /*
    messageEvent.origin: Protocol and domain origin of the message
    messageEvent.data: Message itself
@@ -41,6 +41,16 @@ window.onload=function(){
 };
 ```
 
+NOTE: In case you do not want to support post messages for legacy browsers, you can specify null
+as the proxy url. In this case, when on legacy browser this will be a receiver only window. E.g.
+
+```javascript
+    // Create a proxy window to send to and receive 
+    // messages from the iFrame, no sending for legacyBrowsers, receiver only window
+    windowProxy = new Porthole.WindowProxy(
+        null, 'guestFrame');
+```
+
 Create a window proxy object in the iFrame.
 
 ```javascript
@@ -57,6 +67,8 @@ window.onload=function(){
     });
 };
 ```
+
+NOTE: See the above note for receiver only windows.
 
 Send a message.
 

--- a/src/porthole.js
+++ b/src/porthole.js
@@ -238,7 +238,7 @@ iFrame proxy abc.com->abc.com: forwardMessageEvent(event)
      *
      * @private
      * @constructor
-     * @param {string} proxyIFrameUrl - Fully qualified url to proxy iframe
+     * @param {string} proxyIFrameUrl - Fully qualified url to proxy iframe, or null to create a receiver only window
      * @param {string} targetWindowName - Name of the proxy iframe window
      */
     Porthole.WindowProxyLegacy = Porthole.WindowProxyBase.extend({
@@ -254,7 +254,9 @@ iFrame proxy abc.com->abc.com: forwardMessageEvent(event)
             } else {
                 // Won't be able to send messages
                 this.proxyIFrameElement = null;
-                throw  new Error("proxyIFrameUrl can't be null");
+                Porthole.trace("proxyIFrameUrl is null, window will be a receiver only");
+                this.post = function(){ throw new Error("Receiver only window");};
+                //throw  new Error("proxyIFrameUrl can't be null");
             }
         },
 


### PR DESCRIPTION
This adds ability to create receiver only windows when on legacy browsers. in this case one does not have to set up any proxy iframe on the other window (sendin side), because by design this window (receiving side) will not post any message. This can simplify deployment in such cases.