### PR TITLE
This adds two minor mods that ease debuging

### DIFF
--- a/src/porthole.js
+++ b/src/porthole.js
@@ -460,7 +460,7 @@ iFrame proxy abc.com->abc.com: forwardMessageEvent(event)
                             // that is declared to be targetting the window that is calling us
                             if (w[i] !== null &&
                                 typeof w[i] === 'object' &&
-                                w[i] instanceof w.Porthole.WindowProxy &&
+                                w[i] instanceof w.Porthole.WindowProxyBase &&
                                 w[i].getTargetWindowName() === sourceWindowName) {
                                 return w[i];
                             }


### PR DESCRIPTION
Throw errors at event listeners, 
before that is was very difficult to debug event handling code, as all errors where silently ignored.

Loose class check at WindowProxyDispatcher.findWindowProxyObject
Enable to manually instantiate WindowProxyLegacy or WindowProxyHTML5 instead of WindowProxy.
Useful for debugging or when no legacy support is needed.
