### PR TITLE
feat(Porthole): report when event listeners throw errors for debugging purposes

### DIFF
--- a/src/porthole.js
+++ b/src/porthole.js
@@ -132,7 +132,7 @@ iFrame proxy abc.com->abc.com: forwardMessageEvent(event)
          * @private
          */
         error: function(s) {
-            if (window.console !== undefined) {
+            if (typeof window.console !== undefined && typeof window.console.error === 'function') {
                 window.console.error('Porthole: ' + s);
             }
         }
@@ -231,6 +231,7 @@ iFrame proxy abc.com->abc.com: forwardMessageEvent(event)
                 try {
                     this.eventListeners[i](event);
                 } catch(e) {
+                    Porthole.error(e);
                 }
             }
         }


### PR DESCRIPTION
feat(Porthole): report when event listeners throw errors for debugging purposes (Porthole.error)

Currently, when a listener function throws an error the exception is *silently swallowed*.
Debugging information was added in order to improve developer experience.

Porthole.error(e) was also tweaked. Added an additional type check for `window.console.error`.